### PR TITLE
Bump OpenFin runtime version to match Reactive Trader

### DIFF
--- a/client/public/openfin/app.json
+++ b/client/public/openfin/app.json
@@ -21,7 +21,7 @@
     }
   ],
   "runtime": {
-    "version": "16.83.52.32"
+    "version": "17.85.53.10"
   },
   "shortcut": {
     "company": "Adaptive Consulting",


### PR DESCRIPTION
In order for FDC3 interop to work between Reactive Trader and Reactive Analytics, both must be running on the same version of the OpenFin runtime.