### PR TITLE
fix(server): update FX service URL

### DIFF
--- a/server/src/graph-ql/fx/Fx.service.ts
+++ b/server/src/graph-ql/fx/Fx.service.ts
@@ -49,7 +49,7 @@ export default class {
     this.rxStompRPC = new RxStompRPC(this.rxStomp)
 
     this.rxStomp.configure({
-      brokerURL: `ws://web-demo.adaptivecluster.com:80/ws`,
+      brokerURL: 'wss://classic.reactivetrader.com/ws',
       reconnectDelay: 5000,
       heartbeatIncoming: 4000,
       heartbeatOutgoing: 4000,


### PR DESCRIPTION
The FX service cannot connect to the RT broker WebSocket as the URL is no longer valid.