### PR TITLE
chore: k8 api version rollback

### DIFF
--- a/kubernetes/analytics-ingress.yml
+++ b/kubernetes/analytics-ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: analytics-ingress

--- a/kubernetes/nginx-ingress-controller/nginx-ingress-controller.yml
+++ b/kubernetes/nginx-ingress-controller/nginx-ingress-controller.yml
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: nginx-ingress-clusterrole
@@ -105,7 +105,7 @@ rules:
       - update
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: nginx-ingress-role
@@ -150,7 +150,7 @@ rules:
       - get
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-nisa-binding
@@ -168,7 +168,7 @@ subjects:
     namespace: ingress-nginx
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: nginx-ingress-clusterrole-nisa-binding


### PR DESCRIPTION
Rolling back previous apiVersion upgrades as they were not needed for the GKE upgrade and caused issues with the build