### PR TITLE
fix: removed platform.symbolSelected to fix loop

### DIFF
--- a/client/src/containers/search/ApolloSearchContainer.tsx
+++ b/client/src/containers/search/ApolloSearchContainer.tsx
@@ -51,7 +51,7 @@ const ApolloSearchContainer: React.FunctionComponent<Props> = ({ id, history, ur
       }
       if (symbol) {
         clearSymbol()
-        platform.symbolSelected(symbol)
+        // platform.symbolSelected(symbol)
         history.push(`/${(symbol.marketSegment || url || '').toLowerCase()}/${symbol.id}`)
       } else {
         history.push(`/${url}`)


### PR DESCRIPTION
Removed `platform.symbolSelected` when symbol changes. This fixes a loop where the application will broadcast and then run the callback.