### PR TITLE
fix: revert build config changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,8 @@ job_configs:
         - export BUILD_VERSION="$(git describe)"
         - echo "Building ${BUILD_TYPE} docker image ${BUILD_VERSION}"
       script:
-        - docker build
-          -t reactive-analytics-${BUILD_TYPE}:${BUILD_VERSION}
-          --build-arg BUILD_VERSION=${BUILD_VERSION}
-          -f ./${BUILD_TYPE}/Dockerfile .
+        - cd ${BUILD_TYPE}
+        - docker build -t reactive-analytics-${BUILD_TYPE}:${BUILD_VERSION} --build-arg BUILD_VERSION=${BUILD_VERSION} .
 
   - build_and_push_job: &build_and_push_job
       <<: *gcloud_cache
@@ -54,10 +52,8 @@ job_configs:
       before_script:
         - *gcloud_auth
       script:
-        - docker build 
-          -t ${GOOGLE_GCR_HANDLE}/${GOOGLE_PROJECT_ID}/reactive-analytics-${BUILD_TYPE}:${BUILD_VERSION}
-          --build-arg BUILD_VERSION=${BUILD_VERSION}
-          -f ./${BUILD_TYPE}/Dockerfile .
+        - cd ${BUILD_TYPE}
+        - docker build -t ${GOOGLE_GCR_HANDLE}/${GOOGLE_PROJECT_ID}/reactive-analytics-${BUILD_TYPE}:${BUILD_VERSION} --build-arg BUILD_VERSION=${BUILD_VERSION} .
         - gcloud docker -- push ${GOOGLE_GCR_HANDLE}/${GOOGLE_PROJECT_ID}/reactive-analytics-${BUILD_TYPE}:${BUILD_VERSION}
 
   - deploy_job: &deploy_job

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -6,21 +6,20 @@ ARG BUILD_VERSION
 ENV REACT_APP_ANALYTICS_SERVER_HOST=${ANALYTICS_SERVER_HOST}
 ENV REACT_APP_BUILD_VERSION=${BUILD_VERSION}
 
-WORKDIR /app
+WORKDIR /
 COPY . .
-# we are using yarn workspaces, so install must be at top level
 RUN yarn install --frozen-lockfile --non-interactive
-RUN cd client && yarn run build
+RUN yarn run build
 
 FROM openresty/openresty:alpine-fat
 EXPOSE 3000
 
-# Copy website resources
-COPY --from=builder /app/client/build /usr/local/openresty/nginx/html
+# Copy website resourcees
+COPY --from=builder /build /usr/local/openresty/nginx/html
 
 # Install lua template engine
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-template
 
 # Copy nginx config
-COPY ./client/nginx/default.conf /etc/nginx/conf.d/default.conf
-COPY ./client/nginx/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY ./nginx/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,17 +6,16 @@ ENV BUILD_VERSION=${BUILD_VERSION}
 
 WORKDIR /app
 COPY . .
-# we are using yarn workspaces, so install must be at top level
 RUN yarn install --frozen-lockfile --non-interactive
-RUN cd server && yarn run build
+RUN yarn run build
 
 FROM node:12-alpine
 WORKDIR /app
-COPY --from=builder /app/server/lib                   ./lib
-COPY --from=builder /app/server/node_modules          ./node_modules
-COPY --from=builder /app/server/.graphqlconfig        ./
-COPY --from=builder /app/server/graphql.config.json   ./
-COPY --from=builder /app/server/.graphqlrc            ./
-COPY --from=builder /app/server/package.json          ./
+COPY --from=builder /app/lib                   ./lib
+COPY --from=builder /app/node_modules          ./node_modules
+COPY --from=builder /app/.graphqlconfig        ./
+COPY --from=builder /app/graphql.config.json   ./
+COPY --from=builder /app/.graphqlrc            ./
+COPY --from=builder /app/package.json          ./
 
 CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
This reverts part of commit e622fa9d79a3a73b322f291d01ef08ab2f03ba45
which made changes to the build config to work with yarn workspaces.
Those changes broke the Docker build for the server. This commit
leaves the server build as it was, and does not restore client/yarn.lock
which is suboptimal as both client and server are now effectively
building without lockfiles, but brings client to parity with server and
fixes the build for now. We should find an optimal fix that uses lock files
for both client and server and works properly with yarn workspaces.

This duplicates #197 in an effort to trigger a build