### PR TITLE
server Dockerfile update to Node 16 and simplify

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -22,4 +22,4 @@ yarn-error.log*
 
 # Directories
 notes
-node_modules
+# we need this to copy to server docker build:  node_modules

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,21 +1,16 @@
-FROM node:16-alpine as builder
+# FROM node:16-alpine as builder
+FROM node:16-alpine
 
 ARG BUILD_VERSION
-
 ENV BUILD_VERSION=${BUILD_VERSION}
 
+# Copy website resourcees
 WORKDIR /app
-COPY . .
-RUN yarn install --frozen-lockfile --non-interactive
-RUN yarn run build
-
-FROM node:12-alpine
-WORKDIR /app
-COPY --from=builder /app/lib                   ./lib
-COPY --from=builder /app/node_modules          ./node_modules
-COPY --from=builder /app/.graphqlconfig        ./
-COPY --from=builder /app/graphql.config.json   ./
-COPY --from=builder /app/.graphqlrc            ./
-COPY --from=builder /app/package.json          ./
+COPY ./lib                   ./lib
+COPY ./node_modules          ./node_modules
+COPY ./.graphqlconfig        ./
+COPY ./graphql.config.json   ./
+COPY ./.graphqlrc            ./
+COPY ./package.json          ./
 
 CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
recent upgrades were reliant on Node 15+ and although it all worked locally off command line, I hadn't accounted for the old Node 12 in the Dockerfile. This PR simplifies the docker creation along the lines of what we did to the client back in Jan.