### PR TITLE
add playwright test framework and basic tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: Scheduled daily E2E
+name: Reactive Analytics Prod Daily E2E
 
 on:
   schedule:
@@ -13,6 +13,8 @@ jobs:
     name: prod(demo) - e2e
     
     runs-on: ubuntu-20.04
+
+    if: github.repository_owner == 'AdaptiveConsulting'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,38 @@
+name: Scheduled daily E2E
+
+on:
+  schedule:
+    - cron: "45 8 * * *"
+
+defaults:
+  run:
+    working-directory: client
+
+jobs:
+  ra-end-to-end-test:
+    name: prod(demo) - e2e
+    
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set Node version
+        uses: actions/setup-node@v3
+        with:
+            node-version: 20
+
+      - name: Install
+        run: yarn install
+
+      - name: Test
+        env:
+            E2E_RA_WEB_BASE_URL: https://demo-reactive-analytics.adaptivecluster.com
+        run: yarn run e2e:web
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+            name: playwright-report
+            path: packages/client/playwright-report/
+            retention-days: 7

--- a/client/.eslintrc.yml
+++ b/client/.eslintrc.yml
@@ -20,6 +20,7 @@ overrides:
           "@typescript-eslint/no-var-requires": 0,
         },
     },
+    { files: ["e2e/*.ts"], rules: { "no-empty-pattern": 0 } },
   ]
 parser: "@typescript-eslint/parser"
 parserOptions:

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -22,3 +22,6 @@ public/app.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/client/e2e/fixtures.ts
+++ b/client/e2e/fixtures.ts
@@ -1,0 +1,28 @@
+import { chromium, test as base } from "@playwright/test"
+
+export const test = base.extend({
+  browser: async ({}, use) => {
+    const browser = await chromium.launch()
+    await use(browser)
+  },
+  context: async ({ browser }, use) => {
+    try {
+      const contexts = browser.contexts()
+      if (contexts.length !== 1) {
+        throw Error(
+          `Unexpected Context(s): Expected 1, Found ${contexts.length}`,
+        )
+      }
+      await use(contexts[0])
+    } catch (e) {
+      const context = await browser.newContext()
+      use(context)
+    }
+  },
+  reactiveAnalyticsPageRec: async ({ context }, use) => {
+    const contextPages = context.pages()
+    const mainWindow =
+      contextPages.length > 0 ? contextPages[0] : await context.newPage()
+    use(mainWindow)
+  },
+})

--- a/client/e2e/fixtures.ts
+++ b/client/e2e/fixtures.ts
@@ -19,7 +19,7 @@ export const test = base.extend({
       use(context)
     }
   },
-  reactiveAnalyticsPageRec: async ({ context }, use) => {
+  reactiveAnalyticsPage: async ({ context }, use) => {
     const contextPages = context.pages()
     const mainWindow =
       contextPages.length > 0 ? contextPages[0] : await context.newPage()

--- a/client/e2e/reactive-analytics.spec.ts
+++ b/client/e2e/reactive-analytics.spec.ts
@@ -1,0 +1,48 @@
+import { expect, Locator, Page } from "@playwright/test"
+
+import { test } from "./fixtures"
+import { ElementTimeout } from "./utils"
+
+test.describe("Reactive Analytics", () => {
+  const baseUrl = `${process.env.E2E_RA_WEB_BASE_URL}`
+  let reactiveAnalyticsPage: Page
+  let searchBar: Locator
+  let suggestions: Locator
+
+  test.beforeAll(async ({ reactiveAnalyticsPageRec }) => {
+    reactiveAnalyticsPage = reactiveAnalyticsPageRec
+    await reactiveAnalyticsPage.goto(baseUrl)
+
+    searchBar = reactiveAnalyticsPage.getByPlaceholder(
+      /Enter a stock, symbol, or currency pair.../,
+    )
+    suggestions = reactiveAnalyticsPage.getByRole("listbox")
+  })
+
+  test.beforeEach(async () => {
+    await searchBar.clear()
+  })
+
+  test("Suggestions are displayed upon typing in search bar", async () => {
+    await searchBar.pressSequentially("USD")
+    await expect(suggestions).toBeVisible()
+    await expect(suggestions).not.toContainText("No results found...", {
+      timeout: ElementTimeout.AGGRESSIVE,
+    })
+    expect(
+      (await suggestions.getByRole("option").all()).length,
+    ).toBeGreaterThan(0)
+  })
+
+  test("Opens stock page stock selected from suggestions", async () => {
+    await searchBar.pressSequentially("USD")
+    const firstSuggestion = suggestions.getByRole("option").first()
+    const firstSuggestionText = await firstSuggestion.textContent()
+
+    await firstSuggestion.click()
+    await reactiveAnalyticsPage.waitForURL(`${baseUrl}/stock/*`)
+    await reactiveAnalyticsPage.waitForLoadState("networkidle")
+    await expect(searchBar).toBeVisible()
+    await expect(searchBar).toHaveValue(firstSuggestionText)
+  })
+})

--- a/client/e2e/tsconfig.json
+++ b/client/e2e/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./"
+  }
+}

--- a/client/e2e/utils.ts
+++ b/client/e2e/utils.ts
@@ -1,0 +1,10 @@
+export enum ElementTimeout {
+  AGGRESSIVE = 5000,
+  NORMAL = 15000,
+  LONG = 30000,
+  RFQTIMEOUT = 10500,
+}
+export enum TestTimeout {
+  NORMAL = 30000,
+  EXTENDED = 60000,
+}

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,8 @@
     "test:ui": "vitest --ui",
     "coverage": "vitest run --coverage",
     "verify": "yarn typecheck && yarn lint && yarn format:check && yarn test",
-    "openfin": "wait-on -l http://localhost:3005/openfin/app.json && openfin -l -c http://localhost:3005/openfin/app.json"
+    "openfin": "wait-on -l http://localhost:3005/openfin/app.json && openfin -l -c http://localhost:3005/openfin/app.json",
+    "e2e:web": "playwright test --project=chrome"
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
@@ -51,6 +52,7 @@
     "typeface-roboto": "^0.0.75"
   },
   "devDependencies": {
+    "@playwright/test": "1.39.0",
     "@rollup/plugin-graphql": "^2.0.2",
     "@rollup/plugin-replace": "^5.0.1",
     "@testing-library/jest-dom": "^5.16.5",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,0 +1,36 @@
+import { devices, PlaywrightTestConfig } from "@playwright/test"
+
+import { TestTimeout } from "./e2e/utils"
+
+const config: PlaywrightTestConfig = {
+  testDir: "./e2e",
+  /* Maximum time one test can run for. */
+  timeout: TestTimeout.NORMAL,
+  workers: 1,
+  projects: [
+    {
+      name: "chrome",
+      use: {
+        ...devices["Desktop Chrome"], 
+        channel: 'chrome',
+        //Artifacts
+        screenshot: "only-on-failure",
+        video: "retain-on-failure",
+        trace: "retain-on-failure",
+        headless: true,
+      },
+    },
+  ],
+  reporter: [
+    ["list"],
+    [
+      "html",
+      {
+        outputFolder: "playwright-report",
+        open: "never",
+      },
+    ],
+  ],
+}
+
+export default config

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -92,6 +92,7 @@ const setConfig = ({ mode }) => {
       setupFiles: "src/setupTests.ts",
       // setting globals: true gives all tests access to the vitest functions without having to import them everytime
       globals: true,
+      include: ["**/*.test.{tsx,ts}", "**/__tests__/*"]
     },
   })
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -755,6 +755,13 @@
   dependencies:
     lodash "^4.17.21"
 
+"@playwright/test@1.39.0":
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.39.0.tgz#d10ba8e38e44104499e25001945f07faa9fa91cd"
+  integrity sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==
+  dependencies:
+    playwright "1.39.0"
+
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
@@ -2647,7 +2654,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -3854,6 +3861,20 @@ pkg-types@^1.0.3:
     jsonc-parser "^3.2.0"
     mlly "^1.2.0"
     pathe "^1.1.0"
+
+playwright-core@1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.39.0.tgz#efeaea754af4fb170d11845b8da30b2323287c63"
+  integrity sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==
+
+playwright@1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.39.0.tgz#184c81cd6478f8da28bcd9e60e94fcebf566e077"
+  integrity sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==
+  dependencies:
+    playwright-core "1.39.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 polished@^3.2.0:
   version "3.6.5"


### PR DESCRIPTION
- Added playwright test framework latest version `1.39` and added 2 basic tests
- Added  `e2e.yml` to execute e2e tests on a weekday basis against prod (demo)
- https://github.com/AdaptiveConsulting/ReactiveAnalytics/actions/workflows/e2e.yml

** will add more tests coverage on a subsequent iteration under https://adaptive.kanbanize.com/ctrl_board/18/cards/5630/details/ 